### PR TITLE
Remove unneeded shuffle

### DIFF
--- a/NextItem/ViewController.swift
+++ b/NextItem/ViewController.swift
@@ -31,28 +31,17 @@ class ViewController: UIViewController {
 
 //LB: This is the only control for the user, to display an item in the TextViewItem
     @IBAction func NextItemControl(_ sender: UIButton) {
-
-        //Shuffle the Items array and then display the first item
-        Items.shuffle()
         
-        TextViewItem.text=("¡ \(Items[0]) !")
+        // Display a random item
+        
+        // Note that arc3random_uniform (which is a standard BSD function for generating random numbers) expects and returns a UInt32 (a 32-bit unsigned integer value type), but Swift arrays are index using Int types, so we have to convert between them using UInt32() and Int():
+        let numItems = UInt32(Items.count)
+        let randomIndex = Int(arc4random_uniform(numItems))
+        
+        TextViewItem.text=("¡ \(Items[randomIndex]) !")
         
         }
-
     }
-
-//The function and array that get's sorted when the user clicks NextItem, most of the code courtesy of https://gist.github.com/ijoshsmith/5e3c7d8c2099a3fe8dc3
-extension Array
-{
-    /** Randomizes the order of an array's elements. */
-    mutating func shuffle()
-    {
-        for _ in 0..<10
-        {
-            sort { (_,_) in arc4random() < arc4random() }
-        }
-    }
-}
 
 var Items = [
     "Call someone from Contacts, someone you haven't spoken with in the last month", "Drop down and give me 20 pushups and 20 sit-ups, now", "Motion is lotion: do ten minutes of PT, right now", "Motion is lotion: do ten minutes of PT, right now", "Run 1 fast mile", "Run 30 minute intervals", "Run a 5k", "Run a 5k", "Run a 5k", "Run a 10k ", "Run a 10k ", "Run 10 miles", "Read New Mexico history", "Browse a copy of The Rio Grande Sun", "Write 200 words in novel", "Write 400 words in novel", "Respond to a waiting email", "Work on 505 yard", "Hit the prayer closet for 15 minutes", "Sing a joyful song", "Sing a sad song", "Take a walk through the hood", "Drink a liter (of water)", "Drink a liter (of water)", "Eat some veggies", "Eat some veggies", "Read Kindle for an hour", "Read current hard copy book(s) for an hour", "Dust / vacuum / mop / windows / deck 505", "Dust / vacuum / mop / windows / deck 505", "Listen to Spanish lesson", "Listen to Spanish lesson", "Play 1/2 hour guitar (consider Sólo le pido and Jesu, Joy of Man's Desire)", "Play 1/2 hour guitar (consider Sólo le pido and Jesu, Joy of Man's Desire)", "Record guitar song for the Great Collection WIP"]


### PR DESCRIPTION
Congrats on your first app!

As a beginner you have no choice but to depend on example code you find, and the array shuffling function you found works fine for your application, but it might be instructive to see why it is not very good:

```
extension Array
{
    /** Randomizes the order of an array's elements. */
    mutating func shuffle()
    {
        for _ in 0..<10
        {
            sort { (_,_) in arc4random() < arc4random() }
         }
     }
}
```

The function shuffles the array by sorting it ten times with a predicate that compares 2 random numbers (so that each element is randomly moved to the first or last half of the array). But why 10 times? And why 2 random numbers? Any time random variables interact, it becomes that much harder to keep track of statistics (for me anyway): in this case, what is the probability that the first random number is smaller than the second? It turns out (I _think_) to be 0.5, so it would have been simpler to randomly choose one of two numbers:

```
// Randomly generate a 0 or a 1, and test if it is 0 (50% probability)
sort { _ in arc4random_uniform(2) == 0 }
```

But the real problem is that sorting an array with a random predicate like that does **not** result in a uniform distribution of permutations: some orderings of the array will occur more often than others. I think that is why the author of the code shuffles it 10 times... they probably found that was enough to approximate a uniform distribution.

But that is an inefficient way to end up at something that is not even really uniform. Much better is to use the [Fisher-Yates algorithm](https://en.wikipedia.org/wiki/Fisher–Yates_shuffle), which is a simple way to quickly and uniformly shuffle an array:

```
extension Array
{
    mutating func fisher_yates()
    {
        for i in (0..<count).reversed()
        {
            let j32 = arc4random_uniform(UInt32(i+1))
            let j = Int(j32) // because arc4random_uniform returns a UInt32
            (self[i], self[j]) = (self[j], self[i]) // swap current item with random item at larger index
        }
    }
}
```

But in your case, since you want a random element of the array every time the button is touched, you don't need to shuffle the array at all. You just need to choose a random element to display. That's what the change attached to this pull request does.